### PR TITLE
Add data preprocessing notebook

### DIFF
--- a/data_preprocessing.ipynb
+++ b/data_preprocessing.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "55da9267",
+   "metadata": {},
+   "source": [
+    "# CSC2042S Assignment 1: Data Preprocessing\n",
+    "\n",
+    "This notebook implements Part 1 (Data Preprocessing) of the assignment. It expects the WDI dataset to be located in `CSC2042S-Assignment1-Data/WDICSV.csv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de4b18df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from pathlib import Path\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.manifold import TSNE\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "DATA_DIR = Path('CSC2042S-Assignment1-Data')\n",
+    "WDI_PATH = DATA_DIR / 'WDICSV.csv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "747470f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_wdi_dataset(path: Path) -> pd.DataFrame:\n",
+    "    \"\"\"Load WDI CSV into tidy format with rows as country-year and columns as indicators.\"\"\"\n",
+    "    raw = pd.read_csv(path)\n",
+    "    id_vars = ['Country Name','Country Code','Indicator Name','Indicator Code']\n",
+    "    year_cols = [c for c in raw.columns if c.isdigit()]\n",
+    "    tidy = raw.melt(id_vars=id_vars, value_vars=year_cols,\n",
+    "                    var_name='Year', value_name='Value').dropna(subset=['Value'])\n",
+    "    tidy['Year'] = tidy['Year'].astype(int)\n",
+    "    pivot = tidy.pivot_table(index=['Country Name','Country Code','Year'],\n",
+    "                             columns='Indicator Code', values='Value').reset_index()\n",
+    "    return pivot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f60a571",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def preprocess(df: pd.DataFrame, feature_thresh: float=0.3, sample_thresh: float=0.7) -> pd.DataFrame:\n",
+    "    feature_coverage = df.notna().mean()\n",
+    "    df = df.loc[:, feature_coverage >= feature_thresh]\n",
+    "    sample_coverage = df.notna().mean(axis=1)\n",
+    "    df = df.loc[sample_coverage >= sample_thresh]\n",
+    "    df = df.fillna(df.mean())\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "646d5612",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normalize(df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    scaler = MinMaxScaler()\n",
+    "    numeric = df.select_dtypes(include=[np.number])\n",
+    "    scaled = scaler.fit_transform(numeric)\n",
+    "    df[numeric.columns] = scaled\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "901d021d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def visualize_tsne(df: pd.DataFrame, perplexity: float=30.0, random_state: int=0):\n",
+    "    tsne = TSNE(n_components=2, perplexity=perplexity, random_state=random_state)\n",
+    "    emb = tsne.fit_transform(df.select_dtypes(include=[np.number]))\n",
+    "    plt.figure(figsize=(6,5))\n",
+    "    plt.scatter(emb[:,0], emb[:,1], s=5)\n",
+    "    plt.title('t-SNE Visualization')\n",
+    "    plt.xlabel('Dim 1')\n",
+    "    plt.ylabel('Dim 2')\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a7ac71b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load dataset\n",
+    "data = load_wdi_dataset(WDI_PATH)\n",
+    "print(f'Loaded dataset with shape {data.shape}')\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e792945",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preprocess dataset\n",
+    "processed = preprocess(data, feature_thresh=0.3, sample_thresh=0.7)\n",
+    "print(f'After preprocessing: {processed.shape}')\n",
+    "processed.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7fd8b96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalize features\n",
+    "normalized = normalize(processed)\n",
+    "normalized.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46f06078",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize with t-SNE\n",
+    "visualize_tsne(normalized.drop(columns=['Country Name','Country Code','Year']))"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Refactor preprocessing notebook into separate stepwise cells
- Include explicit loading, preprocessing, normalization, and t-SNE visualization blocks for clearer graph generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aef6f38b988321ab3c93aee4bac0d1