### PR TITLE
Handle missing values only in numeric columns

### DIFF
--- a/data_preprocessing.ipynb
+++ b/data_preprocessing.ipynb
@@ -60,7 +60,8 @@
     "    df = df.loc[:, feature_coverage >= feature_thresh]\n",
     "    sample_coverage = df.notna().mean(axis=1)\n",
     "    df = df.loc[sample_coverage >= sample_thresh]\n",
-    "    df = df.fillna(df.mean())\n",
+    "    numeric_cols = df.select_dtypes(include=[np.number]).columns\n",
+    "    df[numeric_cols] = df[numeric_cols].fillna(df[numeric_cols].mean())\n",
     "    return df"
    ]
   },


### PR DESCRIPTION
## Summary
- Update preprocessing to fill NaNs only in numeric columns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aefef3d8ac832199ee7d5e49074b81