### PR TITLE
Implement K-means clustering with initialization options

### DIFF
--- a/kmeans.py
+++ b/kmeans.py
@@ -1,0 +1,95 @@
+import numpy as np
+
+
+def initialize_random(X: np.ndarray, k: int, rng: np.random.Generator) -> np.ndarray:
+    """Select k random points from X as initial centroids."""
+    indices = rng.choice(len(X), size=k, replace=False)
+    return X[indices].copy()
+
+
+def initialize_kmeans_plus_plus(X: np.ndarray, k: int, rng: np.random.Generator) -> np.ndarray:
+    """Initialize centroids using the K-means++ strategy."""
+    n_samples = X.shape[0]
+    centroids = np.empty((k, X.shape[1]), dtype=X.dtype)
+    centroids[0] = X[rng.integers(n_samples)]
+    for i in range(1, k):
+        distances = np.min(((X[:, None, :] - centroids[:i]) ** 2).sum(axis=2), axis=1)
+        probs = distances / distances.sum()
+        cumulative_probs = np.cumsum(probs)
+        r = rng.random()
+        index = np.searchsorted(cumulative_probs, r)
+        centroids[i] = X[index]
+    return centroids
+
+
+def kmeans(
+    X: np.ndarray,
+    k: int,
+    init: str = "random",
+    max_iter: int = 300,
+    tol: float = 1e-4,
+    random_state: int | None = None,
+):
+    """Run K-means clustering on data X.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Data array of shape (n_samples, n_features).
+    k : int
+        Number of clusters.
+    init : str
+        Initialization strategy: 'random' or 'kmeans++'.
+    max_iter : int
+        Maximum number of iterations.
+    tol : float
+        Convergence tolerance for centroid movement.
+    random_state : int | None
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    centroids : np.ndarray
+        Final centroids of shape (k, n_features).
+    labels : np.ndarray
+        Cluster assignment for each sample.
+    inertia : float
+        Final sum of squared distances to cluster centres.
+    n_iter : int
+        Number of iterations run.
+    history : list[float]
+        Inertia value at each iteration.
+    """
+
+    rng = np.random.default_rng(random_state)
+    if init == "random":
+        centroids = initialize_random(X, k, rng)
+    elif init == "kmeans++":
+        centroids = initialize_kmeans_plus_plus(X, k, rng)
+    else:
+        raise ValueError("init must be 'random' or 'kmeans++'")
+
+    history = []
+    for i in range(max_iter):
+        # Assign clusters
+        distances = ((X[:, None, :] - centroids[None, :, :]) ** 2).sum(axis=2)
+        labels = distances.argmin(axis=1)
+
+        # Update centroids
+        new_centroids = np.empty_like(centroids)
+        for j in range(k):
+            points = X[labels == j]
+            if len(points) == 0:
+                new_centroids[j] = X[rng.integers(len(X))]
+            else:
+                new_centroids[j] = points.mean(axis=0)
+
+        inertia = float(np.sum((X - new_centroids[labels]) ** 2))
+        history.append(inertia)
+
+        shift = np.linalg.norm(new_centroids - centroids)
+        centroids = new_centroids
+        if shift < tol:
+            break
+
+    return centroids, labels, inertia, i + 1, history

--- a/run_kmeans.py
+++ b/run_kmeans.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from sklearn.preprocessing import MinMaxScaler
+import matplotlib.pyplot as plt
+
+from kmeans import kmeans
+
+DATA_DIR = Path('CSC2042S-Assignment1-Data')
+WDI_PATH = DATA_DIR / 'WDICSV.csv'
+
+
+def load_wdi_dataset(path: Path) -> pd.DataFrame:
+    raw = pd.read_csv(path)
+    id_vars = ['Country Name','Country Code','Indicator Name','Indicator Code']
+    year_cols = [c for c in raw.columns if c.isdigit()]
+    tidy = raw.melt(id_vars=id_vars, value_vars=year_cols,
+                    var_name='Year', value_name='Value').dropna(subset=['Value'])
+    tidy['Year'] = tidy['Year'].astype(int)
+    pivot = tidy.pivot_table(index=['Country Name','Country Code','Year'],
+                             columns='Indicator Code', values='Value').reset_index()
+    return pivot
+
+
+def preprocess(df: pd.DataFrame, feature_thresh: float=0.3, sample_thresh: float=0.7) -> pd.DataFrame:
+    feature_coverage = df.notna().mean()
+    df = df.loc[:, feature_coverage >= feature_thresh]
+    sample_coverage = df.notna().mean(axis=1)
+    df = df.loc[sample_coverage >= sample_thresh]
+    numeric_cols = df.select_dtypes(include=[np.number]).columns
+    df[numeric_cols] = df[numeric_cols].fillna(df[numeric_cols].mean())
+    return df
+
+
+def normalize(df: pd.DataFrame) -> pd.DataFrame:
+    scaler = MinMaxScaler()
+    numeric = df.select_dtypes(include=[np.number])
+    scaled = scaler.fit_transform(numeric)
+    df[numeric.columns] = scaled
+    return df
+
+
+def run_experiment(X: np.ndarray, k: int, init: str, runs: int = 5):
+    results = []
+    for seed in range(runs):
+        centroids, labels, inertia, n_iter, history = kmeans(X, k, init=init, random_state=seed)
+        results.append((inertia, n_iter, history))
+    return results
+
+
+def summarize(results):
+    inertias = [r[0] for r in results]
+    iters = [r[1] for r in results]
+    return np.mean(inertias), np.std(inertias), np.mean(iters)
+
+
+def main():
+    df = load_wdi_dataset(WDI_PATH)
+    df = preprocess(df)
+    df = normalize(df)
+    features = df.drop(columns=['Country Name','Country Code','Year'])
+    X = features.values
+    k = 5
+    for init in ['random','kmeans++']:
+        results = run_experiment(X, k, init, runs=5)
+        mean_inertia, std_inertia, mean_iter = summarize(results)
+        print(f"Initialization: {init}")
+        print(f"  Mean inertia: {mean_inertia:.4f} ± {std_inertia:.4f}")
+        print(f"  Mean iterations: {mean_iter:.2f}")
+
+        # Plot convergence of first run
+        history = results[0][2]
+        plt.plot(history)
+        plt.title(f"Convergence ({init})")
+        plt.xlabel('Iteration')
+        plt.ylabel('Inertia')
+        plt.savefig(f'convergence_{init}.png')
+        plt.clf()
+
+
+if __name__ == '__main__':
+    main()

--- a/test_kmeans.py
+++ b/test_kmeans.py
@@ -1,0 +1,16 @@
+import numpy as np
+from kmeans import kmeans
+
+# synthetic two-cluster dataset
+def main():
+    rng = np.random.default_rng(0)
+    X1 = rng.normal(0, 0.5, (50, 2))
+    X2 = rng.normal(5, 0.5, (50, 2))
+    X = np.vstack([X1, X2])
+    centroids, labels, inertia, n_iter, history = kmeans(X, 2, init='kmeans++', random_state=0)
+    print('centroids:', centroids)
+    print('inertia:', round(inertia, 4))
+    print('iterations:', n_iter)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add NumPy-based K-means implementation with random and K-means++ initialisation
- include experiment script to run clustering with both initialisation strategies and plot convergence

## Testing
- `python test_kmeans.py` *(synthetic data check)*
- ⚠️ `python run_kmeans.py` *(fails: The following id_vars or value_vars are not present in the DataFrame: ['Country Name', 'Country Code', 'Indicator Name', 'Indicator Code'])*

------
https://chatgpt.com/codex/tasks/task_b_68af033cef0083218cad31e2d794a363