### PR TITLE
Save cleaned dataset to CSV in preprocessing notebook

### DIFF
--- a/data_preprocessing.ipynb
+++ b/data_preprocessing.ipynb
@@ -843,6 +843,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c11ccd92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save cleaned dataset for Part 2\n",
+    "output_path = DATA_DIR / 'cleaned_data.csv'\n",
+    "normalized.to_csv(output_path, index=False)\n",
+    "print(f'Cleaned data saved to {output_path}')"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 16,
    "id": "46f06078",
    "metadata": {},


### PR DESCRIPTION
## Summary
- add code cell in `data_preprocessing.ipynb` to persist normalized dataset as `cleaned_data.csv` for Part 2 use

## Testing
- `pytest -q` (no tests found)


------
https://chatgpt.com/codex/tasks/task_b_68af1d7320c0832183853b96b9453852